### PR TITLE
Update azure-deploy.json

### DIFF
--- a/azure-deploy-parameters.json
+++ b/azure-deploy-parameters.json
@@ -5,6 +5,9 @@
     "storageAccountName": {
       "value": "YOUR-STORAGE-ACCOUNT-NAME"
     },
+    "storageEndpoint": {
+      "value": "blob.core.windows.net"
+    },
     "adminSSHKey": {
       "value": "YOUR-RSA-PUBLIC-KEY"
     },

--- a/azure-deploy.json
+++ b/azure-deploy.json
@@ -431,7 +431,7 @@
               "uri": "[concat('https://',parameters('storageAccountName'),'.',parameters('storageEndpoint'),'/opsman-image/image.vhd')]"
             },
             "vhd": {
-              "uri": "[concat('http://',parameters('storageAccountName','.',parameters('storageEndpoint'),'/',variables('vmStorageAccountContainerName'),'/',variables('opsManVMName'),'-osdisk.vhd')]"
+              "uri": "[concat('http://',parameters('storageAccountName'),'.',parameters('storageEndpoint'),'/',variables('vmStorageAccountContainerName'),'/',variables('opsManVMName'),'-osdisk.vhd')]"
             },
             "caching": "ReadWrite",
             "diskSizeGB": "120"

--- a/azure-deploy.json
+++ b/azure-deploy.json
@@ -8,6 +8,12 @@
         "description": "Name of storage account created with Azure CLI"
       }
     },
+    "storageEndpoint": {
+      "type": "string",
+      "metadata": {
+        "description": "Domain prefix for storaged based on the chosen Azure cloud i.e. Commercial, Germany, etc."
+      }
+    },
     "vmSize": {
       "type": "string",
       "defaultValue": "Standard_DS2_v2",
@@ -422,10 +428,10 @@
             "name": "osdisk",
             "createOption": "FromImage",
             "image": {
-              "uri": "[concat('https://',parameters('storageAccountName'),'.blob.core.windows.net/opsman-image/image.vhd')]"
+              "uri": "[concat('https://',parameters('storageAccountName'),'.',parameters('storageEndpoint'),'/opsman-image/image.vhd')]"
             },
             "vhd": {
-              "uri": "[concat('http://',parameters('storageAccountName'),'.blob.core.windows.net/',variables('vmStorageAccountContainerName'),'/',variables('opsManVMName'),'-osdisk.vhd')]"
+              "uri": "[concat('http://',parameters('storageAccountName','.',parameters('storageEndpoint'),'/',variables('vmStorageAccountContainerName'),'/',variables('opsManVMName'),'-osdisk.vhd')]"
             },
             "caching": "ReadWrite",
             "diskSizeGB": "120"


### PR DESCRIPTION
Modified the ARM template to parameterize the current hardcoded storage endpoint (blob.core.windows.net). Other Azure clouds (Germany, China, Gov) have different end points. Users will need to change this for the chosen cloud in the azure-deploy-parameters.json file.

The default value in the parameter file is blob.core.windows.net since this is expected to be the most common value.

Current endpoints are:
Azure China: blob.core.chinacloudapi.cn (https://msdn.microsoft.com/en-us/library/azure/dn578439.aspx)
Azure Gov: blob.core.usgovcloudapi.net (https://docs.microsoft.com/en-us/azure/azure-government/documentation-government-services-storage)
Azure Germany: blob.core.cloudapi.de (https://docs.microsoft.com/en-us/azure/germany/germany-developer-guide)