### PR TITLE
Template validation may fail

### DIFF
--- a/azure-deploy.json
+++ b/azure-deploy.json
@@ -240,7 +240,7 @@
         "publicIPAllocationMethod": "Static",
         "publicIPAddressVersion": "IPv4",
         "dnsSettings": {
-          "domainNameLabel": "[concat(uniquestring(resourceGroup().id, deployment().name))]"
+          "domainNameLabel": "[concat('pcf-ert-',uniquestring(resourceGroup().id, deployment().name))]"
         }
       }
     },


### PR DESCRIPTION
Domain name for Azure cannot start with digits.

Current implementation might generate domain name started with a digit for ERT Public IP and cause the validation to fail.