### PR TITLE
Make the storage account name unique

### DIFF
--- a/azure-deploy.json
+++ b/azure-deploy.json
@@ -64,7 +64,7 @@
   "resources": [
     {
       "type": "Microsoft.Storage/storageAccounts",
-      "name": "[concat('pcfblobs', uniqueString(subscription().id))]",
+      "name": "[concat('pcfblobs', uniqueString(subscription().id, resourceGroup().id))]",
       "apiVersion": "2017-06-01",
       "location": "[parameters('location')]",
       "tags": {


### PR DESCRIPTION
The returned value of `uniqueString` is not a random string, but rather the result of a hash function.
https://docs.microsoft.com/en-us/azure/azure-resource-manager/resource-group-template-functions-string#uniquestring

Using `uniqueString(subscription().id)` returns a same value for a same subscription.
Since the resource group name is unique in a subscription, so it should be safe to use both of them to generate the unique string.